### PR TITLE
Closes #3: Make DateRangePicker.Range an opaque type.

### DIFF
--- a/src/DateRangePicker.elm
+++ b/src/DateRangePicker.elm
@@ -188,14 +188,14 @@ initToday config selected =
 getCalendars : Config -> Maybe Range -> Posix -> ( Posix, Posix )
 getCalendars config maybeRange today =
     case ( config.allowFuture, maybeRange ) of
-        ( True, Just { begin } ) ->
-            ( begin |> TE.startOfMonth utc
-            , begin |> Helpers.startOfNextMonth utc
+        ( True, Just range ) ->
+            ( range |> Range.beginsAt |> TE.startOfMonth utc
+            , range |> Range.beginsAt |> Helpers.startOfNextMonth utc
             )
 
-        ( False, Just { end } ) ->
-            ( end |> Helpers.startOfPreviousMonth utc
-            , end |> TE.startOfMonth utc
+        ( False, Just range ) ->
+            ( range |> Range.endsAt |> Helpers.startOfPreviousMonth utc
+            , range |> Range.endsAt |> TE.startOfMonth utc
             )
 
         ( _, Nothing ) ->
@@ -241,9 +241,9 @@ open opened (State internal) =
 
 {-| Assign a DateRangePicker.Range value to the DateRangePicker.
 
-    import DateRangePicker.Range exposing (Range)
+    import DateRangePicker.Range as Range
 
-    state |> setRange (Range begin end)
+    state |> setRange (Range.create begin end)
 
 -}
 setRange : Maybe Range -> State -> State
@@ -327,34 +327,22 @@ defaultPredefinedRanges today =
             posix |> TE.addDays -n |> TE.startOfDay utc
     in
     [ ( "Today"
-      , { begin = TE.startOfDay utc today
-        , end = TE.endOfDay utc today
-        }
+      , Range.create (TE.startOfDay utc today) (TE.endOfDay utc today)
       )
     , ( "Yesterday"
-      , { begin = today |> daysBefore 1 |> TE.startOfDay utc
-        , end = today |> daysBefore 1 |> TE.endOfDay utc
-        }
+      , Range.create (today |> daysBefore 1 |> TE.startOfDay utc) (today |> daysBefore 1 |> TE.endOfDay utc)
       )
     , ( "Last 7 days"
-      , { begin = today |> daysBefore 7
-        , end = today |> TE.startOfDay utc |> TE.addMillis -1
-        }
+      , Range.create (today |> daysBefore 7) (today |> TE.startOfDay utc |> TE.addMillis -1)
       )
     , ( "Last 30 days"
-      , { begin = today |> daysBefore 30
-        , end = today |> TE.startOfDay utc |> TE.addMillis -1
-        }
+      , Range.create (today |> daysBefore 30) (today |> TE.startOfDay utc |> TE.addMillis -1)
       )
     , ( "This month"
-      , { begin = today |> TE.startOfMonth utc
-        , end = today
-        }
+      , Range.create (today |> TE.startOfMonth utc) today
       )
     , ( "Last month"
-      , { begin = today |> Helpers.startOfPreviousMonth utc
-        , end = today |> TE.startOfMonth utc |> TE.addMillis -1
-        }
+      , Range.create (today |> Helpers.startOfPreviousMonth utc) (today |> TE.startOfMonth utc |> TE.addMillis -1)
       )
     ]
 

--- a/src/DateRangePicker/Calendar.elm
+++ b/src/DateRangePicker/Calendar.elm
@@ -1,6 +1,6 @@
 module DateRangePicker.Calendar exposing (fromPosix, view, weekdayNames)
 
-import DateRangePicker.Helpers as Helpers
+import DateRangePicker.Helpers as Helpers exposing (sameDay)
 import DateRangePicker.Range as Range
 import DateRangePicker.Step as Step exposing (Step)
 import Html exposing (..)
@@ -68,15 +68,15 @@ dayCell { allowFuture, noOp, pick, step, target, today } day =
 
                 Step.Begin begin ->
                     { base
-                        | active = Helpers.sameDay utc begin day
-                        , start = Helpers.sameDay utc begin day
+                        | active = sameDay utc begin day
+                        , start = sameDay utc begin day
                     }
 
                 Step.Complete range ->
                     { base
-                        | active = Helpers.sameDay utc range.begin day || Helpers.sameDay utc range.end day
-                        , start = Helpers.sameDay utc range.begin day
-                        , end = Helpers.sameDay utc range.end day
+                        | active = (range |> Range.beginsAt |> sameDay utc day) || (range |> Range.endsAt |> sameDay utc day)
+                        , start = range |> Range.beginsAt |> sameDay utc day
+                        , end = range |> Range.endsAt |> sameDay utc day
                         , inRange = Range.between range day
                     }
 
@@ -86,7 +86,7 @@ dayCell { allowFuture, noOp, pick, step, target, today } day =
     td
         ([ classList
             [ ( "EDRPCalendar__cell", True )
-            , ( "EDRPCalendar__cell--today", Helpers.sameDay utc day today )
+            , ( "EDRPCalendar__cell--today", sameDay utc day today )
             , ( "EDRPCalendar__cell--active", active )
             , ( "EDRPCalendar__cell--inRange", inRange )
             , ( "EDRPCalendar__cell--start", start )

--- a/src/DateRangePicker/Range.elm
+++ b/src/DateRangePicker/Range.elm
@@ -44,7 +44,13 @@ type alias InternalRange =
     }
 
 
-{-| Creates a [`Range`](#Range).
+{-| Creates a [`Range`](#Range) from two Posix timestamps.
+
+Notes:
+
+  - args order is not important as it's internally managed.
+  - A Range is always treated as expressed in UTC.
+
 -}
 create : Posix -> Posix -> Range
 create begin end =

--- a/src/DateRangePicker/Step.elm
+++ b/src/DateRangePicker/Step.elm
@@ -1,6 +1,6 @@
 module DateRangePicker.Step exposing (Step(..), fromMaybe, next, toMaybe)
 
-import DateRangePicker.Range exposing (Range)
+import DateRangePicker.Range as Range exposing (Range)
 import Time exposing (Posix)
 
 
@@ -20,10 +20,10 @@ next picked step =
     case step of
         Begin begin ->
             if picked == begin then
-                Complete { begin = begin, end = begin }
+                Complete (Range.create begin begin)
 
             else if Time.posixToMillis picked > Time.posixToMillis begin then
-                Complete { begin = begin, end = picked }
+                Complete (Range.create begin picked)
 
             else
                 Begin picked

--- a/tests/DateRangePickerTest.elm
+++ b/tests/DateRangePickerTest.elm
@@ -126,6 +126,16 @@ rangeTests =
                 |> Expect.equal False
                 |> asTest "should test if a datetime is before a range"
             ]
+        , describe "create"
+            [ Range.create begin end
+                |> Range.toTuple
+                |> Expect.equal ( begin, end )
+                |> asTest "should create a Range"
+            , Range.create end begin
+                |> Range.toTuple
+                |> Expect.equal ( begin, end )
+                |> asTest "should ensure consistency"
+            ]
         , describe "decode"
             [ sampleJsonRange
                 |> Decode.decodeString Range.decode
@@ -140,7 +150,7 @@ rangeTests =
                 |> asTest "should encode a Range"
             ]
         , describe "format"
-            [ { begin = begin, end = begin |> TE.addHours 12 }
+            [ Range.create begin begin
                 |> Range.format utc
                 |> Expect.equal "on 2018-01-01"
                 |> asTest "should format a single day date range"
@@ -167,9 +177,14 @@ begin =
     TE.fromDateTuple utc ( 2018, Time.Jan, 1 )
 
 
+end : Posix
+end =
+    begin |> TE.addDays 7 |> TE.endOfDay utc
+
+
 sampleRange : Range
 sampleRange =
-    { begin = begin, end = begin |> TE.addDays 7 |> TE.endOfDay utc }
+    Range.create begin end
 
 
 sampleJsonRange : String


### PR DESCRIPTION
This patch tries to addres #3 by turning the `DateRangePicker.Range` type into an opaque one, adding `create`, `beginsAt` and `endsAt` helpers for public data consumption.

The `create` function ensures range data are consistent, by ensuring the end Posix is always greater than the start one.

