### PR TITLE
Add a time zone option.

### DIFF
--- a/src/DateRangePicker/Range.elm
+++ b/src/DateRangePicker/Range.elm
@@ -60,7 +60,7 @@ create begin end =
             Range { begin = end, end = begin }
 
         _ ->
-            Range { begin = begin, end = end |> TE.endOfDay Time.utc }
+            Range { begin = begin, end = end }
 
 
 {-| Retrieves the Posix the [`Range`](#Range) begins at.

--- a/tests/DateRangePickerTest.elm
+++ b/tests/DateRangePickerTest.elm
@@ -26,7 +26,7 @@ calendarTests =
     describe "Calendar"
         [ describe "fromPosix"
             [ TE.fromDateTuple utc ( 2019, Time.Jul, 1 )
-                |> Calendar.fromPosix Time.Mon
+                |> Calendar.fromPosix Time.utc Time.Mon
                 |> toTestableCalendar
                 |> Expect.equal
                     [ [ 24, 25, 26, 27, 28, 29, 30 ]
@@ -38,7 +38,7 @@ calendarTests =
                     ]
                 |> asTest "should compute a calendar with weeks starting on Monday"
             , TE.fromDateTuple utc ( 2019, Time.Jul, 1 )
-                |> Calendar.fromPosix Time.Sun
+                |> Calendar.fromPosix Time.utc Time.Sun
                 |> toTestableCalendar
                 |> Expect.equal
                     [ [ 30, 1, 2, 3, 4, 5, 6 ]


### PR DESCRIPTION
This patch adds a new `zone` config option so users can pass their locale timezone and date ranges, while still expressed as UTC, are computed based on the related offset.